### PR TITLE
TT-168: show error in case of failing logic of approving reports

### DIFF
--- a/components/layout/pending_time_report_notifications.vue
+++ b/components/layout/pending_time_report_notifications.vue
@@ -35,11 +35,15 @@ export default {
     ...mapMutations(["updateSnack"]),
 
     async approve(id){
-      await this.approveTimeReport(id)
-      this.updateSnack({
-        message: this.$t("time_reports.you_approved_this"),
-        color: "green"
-      })
+      try {
+        await this.approveTimeReport(id)
+        this.updateSnack({
+          message: this.$t("time_reports.you_approved_this"),
+          color: "green"
+        })
+      } catch(errors){
+        this.updateSnack({ message: errors.base[0], color: "red" })
+      }
     }
   }
 }

--- a/test/specs/components/layout/pending_time_report_notifications/methods/approve.spec.js
+++ b/test/specs/components/layout/pending_time_report_notifications/methods/approve.spec.js
@@ -27,4 +27,15 @@ describe('approve', () => {
     sinon.restore()
   });
 
+  it('should show notification in case of fail', async () => {
+    const wrapper = createWrapper(Notifications, {}, fakeStoreData())
+    const actionStub = sinon.stub(wrapper.vm, "approveTimeReport").rejects({ base: ["Big message of fail"] })
+    const snackStub = sinon.stub(wrapper.vm, "updateSnack")
+
+    await wrapper.vm.approve(1)
+    expect(snackStub.calledOnceWith({ message: "Big message of fail", color: "red"})).to.be.true
+
+    actionStub.restore()
+  });
+
 });


### PR DESCRIPTION
https://trello.com/c/7kFJ7nln/168-handle-case-with-stopping-time-record-for-blocked-period